### PR TITLE
feat: preserve folder file structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ which provides additional functions apart from standard library.
 You can pipe the input or `<` direct it to subvars.
 
 Options to [render all files](https://subvars.lmno.pk/03-usage-examples/) in a given folder
-and output to another folder is available via `dir` subcommand.
+and output to another folder preserving folder and file structure is available via `dir` subcommand.
 
 
 ## Installation

--- a/cmd/assist/assist.go
+++ b/cmd/assist/assist.go
@@ -4,7 +4,6 @@ package assist
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -37,13 +36,7 @@ func GetVars() (enVars map[string]string) {
 // ParseString will parse any input provided as string
 func ParseString(str string) (*template.Template, error) {
 	funcMap := sprig.TxtFuncMap()
-	return template.Must(template.New("").Funcs(funcMap).Funcs(matchFunc()).Parse(str)), nil
-}
-
-// ParseFile will parse any input provided as string
-func ParseFile(file string) (*template.Template, error) {
-	funcMap := sprig.TxtFuncMap()
-	return template.Must(template.New(filepath.Base(file)).Funcs(funcMap).Funcs(matchFunc()).ParseFiles(file)), nil
+	return template.Must(template.New("").Funcs(funcMap).Funcs(MatchFunc()).Parse(str)), nil
 }
 
 // MatchPrefix will match a given prefix pattern of all env variables and render only those.
@@ -58,8 +51,8 @@ func MatchPrefix(prefix string) map[string]string {
 	return enVars
 }
 
-// matchFunc returns a custom functions map
-func matchFunc() template.FuncMap {
+// MatchFunc returns a custom functions map
+func MatchFunc() template.FuncMap {
 	functionMap := map[string]interface{}{
 		"match": MatchPrefix,
 	}

--- a/cmd/assist/assist_test.go
+++ b/cmd/assist/assist_test.go
@@ -1,7 +1,6 @@
 package assist
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -59,29 +58,6 @@ func TestMatchPrefix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := MatchPrefix(tt.prefix); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("MatchPrefix() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-//nolint
-func TestParseFile(t *testing.T) {
-	tmpFile, _ := ioutil.TempFile(os.TempDir(), "prefix-")
-	filename := tmpFile.Name()
-	defer os.Remove(tmpFile.Name())
-	tests := []struct {
-		name    string
-		file    string
-		wantErr bool
-	}{
-		{"Parse files", filename, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := ParseFile(tt.file)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseFile() error = %v, wantErr %v", err, tt.wantErr)
-				return
 			}
 		})
 	}

--- a/cmd/dir/dir_test.go
+++ b/cmd/dir/dir_test.go
@@ -58,3 +58,24 @@ func Test_getPathInDir(t *testing.T) {
 		})
 	}
 }
+
+//nolint
+func Test_parseFile(t *testing.T) {
+	tmpFile, _ := ioutil.TempFile(os.TempDir(), "prefix-")
+	filename := tmpFile.Name()
+	defer os.Remove(tmpFile.Name())
+	tests := []struct {
+		name    string
+		file    string
+		wantErr bool
+	}{
+		{"Parse files", filename, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseFile(tt.file); reflect.DeepEqual(got, tt.wantErr) {
+				t.Errorf("parseFile() = %v, want %v", got, tt.wantErr)
+			}
+		})
+	}
+}

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -9,9 +9,9 @@ subvars dir [command options] [arguments...]
 ```
 
 * Directory `dir` subcommand lets you render all files in a folder & subfolder, and writes the output to `stdout`.
-  you can also set an output folder where rendered files will be saved insted of stdout with `--out` flag. The filename will be same. If the folder does not exists it will be created automatically.
+  you can also set an output folder where rendered files will be saved instead of stdout with `--out` flag. The filename will be same. If the folder does not exist it will be created automatically.
 * `subvars` reads the template directly from `stdin`
-* Renderd output will be written to `stdout`
+* Rendered output will be written to `stdout`
 
 ## Flags
 
@@ -22,8 +22,7 @@ subvars dir [command options] [arguments...]
 
 * Missing keys in the template will be substituted with the string `<no value>`.
 
-* If `missingkey` is set to `zero`, missing keys will be substituted with zero value of data type (ie: an empty
-  string).
+* If `missingkey` is set to `zero`, missing keys will be substituted with zero value of data type (i.e: an empty string).
 
 * If `missingkey` is set to `error`, `subvars` will fail and
   returns an error to the caller when missing any key.
@@ -41,9 +40,11 @@ It can also be configured by exporting environment variable `SUBVARS_INPUTDIR`.
 
 
 ### Out
-Input flag `--out` is available for the subcommand `dir`, when using subcommand you can specify an output folder where rendered files will be saved.
+Flag `--out` is available for the subcommand `dir`, when using subcommand you can specify an output folder
+where rendered files will be saved.
 
-If the folder does not exist it will be created automatically, the output filename will remain the same as input templates.
+If the folder does not exist it will be created automatically, preserving subfolder and file structure 
+the output filename will remain the same as input templates.
 
 This setting can also be configured by exporting environment variable `SUBVARS_OUTDIR`.
 


### PR DESCRIPTION
# Description

This will add feature to preserve folder structure of input directory if there are any subfolders, and output will be rendered same way.

Fixes: https://github.com/kha7iq/subvars/issues/6

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

#  Checklist:

- [x] My code has been formated (`make fmt`)
- [x] My code has been linted (`make lint`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch to include the latest changes from `master`
